### PR TITLE
Update MapProxy Image to latest version and use a 2 stages build to reduce size

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -39,7 +39,7 @@ elif [ -f "/mapproxy/swi-mapproxy-configuration/mapproxy.yaml" ]; then
     envsubst < /mapproxy/swi-mapproxy-configuration/mapproxy.yaml > /mapproxy/config/mapproxy.yaml
 else
     echo "Using default mapproxy configuration"
-    envsubst < /mapproxy/mapproxy.yaml.default > /mapproxy/config/mapproxy.yaml
+    envsubst < /mapproxy/user_config/mapproxy.yaml.default > /mapproxy/config/mapproxy.yaml
 fi
 
 # Copy Metadata if exists


### PR DESCRIPTION
This PR introduce a 2 build stage to reduce the runtime image size as well as updating Mapproxy to the latest version. 